### PR TITLE
Prefill Prior Forecasts

### DIFF
--- a/app/controllers/view.go
+++ b/app/controllers/view.go
@@ -26,8 +26,9 @@ func (c View) Index(sid string) revel.Result {
 
 		f := models.ViewScenario(sid)
 		u :=  c.Session["user"]
+		myForecast := models.ViewUserScenarioResults(u, sid)
 
-		return c.Render(f, u)
+		return c.Render(f, u, myForecast)
 }
 
 func (c View) Conclude(sid string, resultIndex int) revel.Result {

--- a/app/models/Forecast.go
+++ b/app/models/Forecast.go
@@ -53,6 +53,17 @@ func ViewScenarioResults (sid string) (c []Forecast) {
     return c
 }
 
+func ViewUserScenarioResults (uid string, sid string) (userForecast Forecast) {
+  results := ViewScenarioResults(sid)
+  for _, result := range results {
+    if result.User == uid {
+      userForecast = result
+    }
+  }
+
+  return userForecast
+}
+
 func DeleteScenarioForecasts(sid string) {
 
     fs := ViewScenarioResults(sid)

--- a/app/views/View/Index.html
+++ b/app/views/View/Index.html
@@ -6,8 +6,7 @@
 <script>
 
 $(document).ready(function(){
-
-    $("input").change(function(){
+    function handleForecastChange() {
       var total = 0;
 
       console.log( "Handler for .change() called." );
@@ -18,8 +17,10 @@ $(document).ready(function(){
         total += parseInt(arr[i].value, 10) || 0;
       }
       $("#total").val(total);
+    }
 
-    })
+    $("input").change(handleForecastChange);
+    handleForecastChange();
 });
 </script>
 <script>
@@ -88,7 +89,7 @@ $(document).ready(function(){
 
         <div class="row">
           <div class="col-2 input-group ">
-            <input name="value[]" value="{{if $.f.Results}}{{index $.f.Results $index}}{{end}}" type="text" class="form-control odds" {{if $.f.Results}}disabled{{end}} aria-label="Percentage of possiblity">
+            <input name="value[]" value="{{if $.myForecast.Forecasts}}{{index $.myForecast.Forecasts $index}}{{end}}" type="text" class="form-control odds" {{if $.f.Results}}disabled{{end}} aria-label="Percentage of possiblity">
             <div class="input-group-append">
               <span class="input-group-text">%</span>
             </div>


### PR DESCRIPTION
The bug seemed to be in the confusion that scenario results held forecast values, but that stores an array of the averages after the scenario has concluded.

The fix was to fetch the scenario forecast for the current user and call the `handleForecastChange()` onload so the total is calculated if the forecast is prepoplated (small side effect is that on a new Scenario it displays 0).

<img width="794" alt="screen shot 2018-05-12 at 11 37 16 pm" src="https://user-images.githubusercontent.com/245096/39964629-74dd0cf6-563d-11e8-966e-97064255df64.png">
