### PR TITLE
Preserve newlines in Scenario description

### DIFF
--- a/app/views/View/Index.html
+++ b/app/views/View/Index.html
@@ -41,7 +41,7 @@ $(document).ready(function(){
         <h2>{{.f.Title}}</h2>
         <pre style="display:none">{{.f.Sid}}</pre>
           <p class="card-text">
-            {{.f.Description}}
+            {{nl2br .f.Description}}
           </p>
       </div>
   </div>


### PR DESCRIPTION
If you attempt to use newlines in your description, like so

<img width="1150" alt="screen shot 2018-05-13 at 1 20 14 pm" src="https://user-images.githubusercontent.com/245096/39971603-e80bf370-56b2-11e8-84ac-130f5e3ddd3c.png">

They will get ignored and you will see:

<img width="1153" alt="screen shot 2018-05-13 at 1 37 05 pm" src="https://user-images.githubusercontent.com/245096/39971607-f4d78c9a-56b2-11e8-8dc9-6a4f828eb5b4.png">

Makes it kinda hard to read, so short of going full on markdown which would be a new security risk, we can leverage the [nl2br](https://revel.github.io/manual/templates-go.html#nl2br) template function that Revel adds. Once we use that, we get a little bit nicer formatting:

<img width="1154" alt="screen shot 2018-05-13 at 1 36 40 pm" src="https://user-images.githubusercontent.com/245096/39971621-362b7eb8-56b3-11e8-9c9e-d423cd2a4342.png">

If you think this is good enough, maybe we should add it to a few of the other places we display the description?