### PR TITLE
Remove unnecessary id-index

### DIFF
--- a/app/models/Forecast.go
+++ b/app/models/Forecast.go
@@ -43,7 +43,7 @@ func CreateForecast(u string, f []float64, sid string, hd string) {
 func ViewScenarioResults(sid string) (c []Forecast) {
 	//Need to do a HD check here to prevent IDOR.
 
-	result := GetPrimaryIndexItem(sid, "id", "id-index", answerTable)
+	result := GetPrimaryItem(sid, "id", answerTable)
 
 	c = []Forecast{}
 

--- a/app/models/Range.go
+++ b/app/models/Range.go
@@ -46,7 +46,7 @@ func CreateRange (u string, min float64, max float64, eid string, hd string) {
 func ViewEstimateResults (eid string) (rs []Range) {
   //Need to do a HD check here to prevent IDOR.
 
-    result := GetPrimaryIndexItem(eid, "id", "id-index", answerTable)
+    result := GetPrimaryItem(eid, "id", answerTable)
 
     rs = []Range{}
 

--- a/app/models/Rank.go
+++ b/app/models/Rank.go
@@ -162,7 +162,7 @@ func DeleteRankSorts(rid string) {
 func ViewRankResults (rid string) (s []Sort) {
   //Need to do a HD check here to prevent IDOR.
 
-    result := GetPrimaryIndexItem(rid, "id", "id-index", "answers-tf")
+    result := GetPrimaryItem(rid, "id", "answers-tf")
 
     s = []Sort{}
 

--- a/app/models/qa.go
+++ b/app/models/qa.go
@@ -144,7 +144,7 @@ func (q Question) WriteRecord(message string, user string) (err error) {
 func ViewQuestionAnswers(id string) (as []Answer) {
 	//Need to do a HD check here to prevent IDOR.
 
-	result := GetPrimaryIndexItem(id, "id", "id-index", answerTable)
+	result := GetPrimaryItem(id, "id", answerTable)
 
 	as = []Answer{}
 

--- a/tf/dynamodb.tf
+++ b/tf/dynamodb.tf
@@ -45,14 +45,6 @@ resource "aws_dynamodb_table" "answers" {
   }
 
   global_secondary_index {
-    name               = "id-index"
-    hash_key           = "id"
-    write_capacity     = 1
-    read_capacity      = 1
-    projection_type    = "ALL"
-  }
-
-  global_secondary_index {
     name               = "ownerid-index"
     hash_key           = "ownerid"
     write_capacity     = 1


### PR DESCRIPTION
This commit removes the id-index secondary index. Since index
is a primary key, we don't need to look it up by index.